### PR TITLE
Use Materialized Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ Another limitation is of course the length of the path field. As IDs get larger
 the possible depth of the hierarchy is reduced. The realistic maximum depth of
 unencoded IDs is around 10, varying with the length of the IDs.
 
-Encoding the IDs as base 32 increases the possible depth to around 50. If this
-is too limiting, I'd suggest either using one of the other two solutions
-(Nested Set or Closure Table).
+Encoding the IDs as base 36 and using fixed-width IDs instead of seperators
+increases the possible depth to 50 and the max ID to 60466174. This is by no means
+infinite, however it is quite generous. If this is still too limiting, I'd
+suggest either using one of the other two solutions (Nested Set or Closure Table).
 
 #### How I've implemented it
 

--- a/README.md
+++ b/README.md
@@ -66,5 +66,45 @@ hierarchical data in relational databases. Nested Set, Materialised path, and
 Closure Table. Nested set stores left and right values for each element in the
 hierarchy so that querying part of the hierarchy, and updating it, is inexpensive.
 Materialised path stores a string representation of the path to the root node
-as a field on the entity. The Closure Table solution uses a sepearate table to
+as a field on the node. The Closure Table solution uses a sepearate table to
 store all relationships to all of the ancestors of a given node, including itself.
+
+### Choosing a solution
+
+I have personally worked on Closure Table solutions in the past and I recognise
+they are quite efficient and easy to query, however I would like to demonstrate
+here my ability to learn a new thing by implmenting the Materialised Path solution.
+I did also consider the Nested Set solution, and could implement that using a
+helper library, but it turned out to be far too complex to implement myself.
+
+This reduces the number of queries to equal to the number of root nodes plus one
+to get the root nodes.
+
+### Materialised Path
+
+Each Store receives a string path containg it's ID. For example:
+
+```
+/1 the root store
+/1/2 a branch of the root store
+/1/3 another branch of the root store
+/1/2/4 a third level branch
+```
+
+Querying for a slice of the hierarchy - all the descendants of a mid level
+branch for example - is easy. Simply query by the path with a wildcard.
+
+Removing all an node's descendants is simple enough also, and no other records
+need to be affected by the deletion.
+
+Reparenting an node is a fairly simple matter of recursively rewriting the
+paths of all the child nodes (so long as we remember to populate the tree first!)
+
+Interestingly, a limitation of this solution is that finding direct descendants
+of a particular node is somewhat more difficult, however that was not a part of
+the specification for this challenge.
+
+Another limitation is of course the length of the path field. As IDs get larger
+the possible depth of the hierarchy is reduced. If this is too limiting, I'd
+suggest either using one of the other two solutions (Nested Set or Closure Table)
+or encoding the IDs for storage, to limit their length.

--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ of a particular node is somewhat more difficult, however that was not a part of
 the specification for this challenge.
 
 Another limitation is of course the length of the path field. As IDs get larger
-the possible depth of the hierarchy is reduced. If this is too limiting, I'd
-suggest either using one of the other two solutions (Nested Set or Closure Table)
-or encoding the IDs for storage, to limit their length.
+the possible depth of the hierarchy is reduced. The realistic maximum depth of
+unencoded IDs is around 10, varying with the length of the IDs.
+
+Encoding the IDs as base 32 increases the possible depth to around 50. If this
+is too limiting, I'd suggest either using one of the other two solutions
+(Nested Set or Closure Table).
 
 #### How I've implemented it
 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,23 @@ Another limitation is of course the length of the path field. As IDs get larger
 the possible depth of the hierarchy is reduced. If this is too limiting, I'd
 suggest either using one of the other two solutions (Nested Set or Closure Table)
 or encoding the IDs for storage, to limit their length.
+
+#### How I've implemented it
+
+I've put queries relating to the tree structure (get root nodes, get branches,
+delete branches) into TreeRepository.php. The queries are super-simple to
+understand.
+
+I've created a couple of traits for the path functionality and the tree
+functionality.
+
+TreeTrait's buildTree method simply associates child nodes with their parents.
+This allows one parent to have a fully constructed hierarchy if provided with
+all of it's descendants.
+
+PathTrait's methods manage generating the new path for a node when changing
+it's parent node. setChildOf is designed to wrap the existing setParent function
+with the new functionality for setting a path.
+
+Hopefully this is all fairly minimal, easy to follow, and functional. I've
+fully unit tested everything.

--- a/src/Controller/StoresController.php
+++ b/src/Controller/StoresController.php
@@ -56,7 +56,7 @@ class StoresController extends AbstractFOSRestController implements ClassResourc
     $store->setName($request->get('name'));
     $this->entityManager->persist($store);
     $this->entityManager->flush();
-    $store->setPath(PathInterface::PATH_SEPARATOR . $store->getEncodedId());
+    $store->setPath($store->getEncodedId());
     $this->entityManager->flush();
     return $store;
   }

--- a/src/Controller/StoresController.php
+++ b/src/Controller/StoresController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Store;
+use App\Entity\PathInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use FOS\RestBundle\Controller\Annotations as REST;
@@ -54,6 +55,8 @@ class StoresController extends AbstractFOSRestController implements ClassResourc
     $store = new Store();
     $store->setName($request->get('name'));
     $this->entityManager->persist($store);
+    $this->entityManager->flush();
+    $store->setPath(PathInterface::PATH_SEPARATOR . $store->getID());
     $this->entityManager->flush();
     return $store;
   }

--- a/src/Controller/StoresController.php
+++ b/src/Controller/StoresController.php
@@ -56,7 +56,7 @@ class StoresController extends AbstractFOSRestController implements ClassResourc
     $store->setName($request->get('name'));
     $this->entityManager->persist($store);
     $this->entityManager->flush();
-    $store->setPath(PathInterface::PATH_SEPARATOR . $store->getID());
+    $store->setPath(PathInterface::PATH_SEPARATOR . $store->getEncodedId());
     $this->entityManager->flush();
     return $store;
   }

--- a/src/DataFixtures/StoreFixtures.php
+++ b/src/DataFixtures/StoreFixtures.php
@@ -16,7 +16,7 @@ class StoreFixtures extends Fixture
         $manager->persist($root);
         $this->addBranches($root, $manager);
         $manager->flush();
-        $root->setPath('/' . $root->getId());
+        $root->setPath('/' . $root->getEncodedId());
         foreach ($root->getBranches() as $branch) {
           $branch->setChildOf($root);
         }
@@ -25,13 +25,13 @@ class StoreFixtures extends Fixture
 
     private function addBranches(BranchInterface $parent, ObjectManager $manager, int $depth = 1)
     {
-      for ($i=0; $i<5; $i++)
+      for ($i=0; $i<1; $i++)
       {
         $branch = new Store();
         $branch->setName(\uniqid() . ' branch');
         $branch->setParent($parent);
         $manager->persist($branch);
-        if ($depth < 5) {
+        if ($depth < 45) {
           $this->addBranches($branch, $manager, $depth + 1);
         }
       }

--- a/src/DataFixtures/StoreFixtures.php
+++ b/src/DataFixtures/StoreFixtures.php
@@ -16,7 +16,7 @@ class StoreFixtures extends Fixture
         $manager->persist($root);
         $this->addBranches($root, $manager);
         $manager->flush();
-        $root->setPath('/' . $root->getEncodedId());
+        $root->setPath($root->getEncodedId());
         foreach ($root->getBranches() as $branch) {
           $branch->setChildOf($root);
         }

--- a/src/DataFixtures/StoreFixtures.php
+++ b/src/DataFixtures/StoreFixtures.php
@@ -31,7 +31,7 @@ class StoreFixtures extends Fixture
         $branch->setName(\uniqid() . ' branch');
         $branch->setParent($parent);
         $manager->persist($branch);
-        if ($depth < 45) {
+        if ($depth < 50) {
           $this->addBranches($branch, $manager, $depth + 1);
         }
       }

--- a/src/DataFixtures/StoreFixtures.php
+++ b/src/DataFixtures/StoreFixtures.php
@@ -16,6 +16,11 @@ class StoreFixtures extends Fixture
         $manager->persist($root);
         $this->addBranches($root, $manager);
         $manager->flush();
+        $root->setPath('/' . $root->getId());
+        foreach ($root->getBranches() as $branch) {
+          $branch->setChildOf($root);
+        }
+        $manager->flush();
     }
 
     private function addBranches(BranchInterface $parent, ObjectManager $manager, int $depth = 1)

--- a/src/Entity/BranchTrait.php
+++ b/src/Entity/BranchTrait.php
@@ -11,14 +11,12 @@ trait BranchTrait
 {
   /**
    * @var BranchInterface
-   * @ORM\ManyToOne(targetEntity="App\Entity\Store", inversedBy="branches")
    * @Serial\Expose()
    * @Serial\Groups("parent")
    */
   private $parent;
   /**
    * @var Collection|BranchInterface[]
-   * @ORM\OneToMany(targetEntity="App\Entity\Store", mappedBy="parent")
    * @Serial\Expose()
    * @Serial\Groups("branches")
    */

--- a/src/Entity/PathInterface.php
+++ b/src/Entity/PathInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Entity;
+
+interface PathInterface
+{
+  const PATH_SEPARATOR = '/';
+
+  public function getId(): ?int;
+
+  public function getPath(): ?string;
+
+  public function getParentPath(): string;
+
+  public function setPath(string $path): void;
+}

--- a/src/Entity/PathInterface.php
+++ b/src/Entity/PathInterface.php
@@ -8,6 +8,8 @@ interface PathInterface
 
   public function getId(): ?int;
 
+  public function getEncodedId(): string;
+
   public function getPath(): ?string;
 
   public function getParentPath(): string;

--- a/src/Entity/PathInterface.php
+++ b/src/Entity/PathInterface.php
@@ -4,7 +4,12 @@ namespace App\Entity;
 
 interface PathInterface
 {
-  const PATH_SEPARATOR = '/';
+
+  const MAX_DEPTH = 50;
+
+  const ID_LENGTH = 5;
+
+  const MAX_LENGTH = 255;
 
   public function getId(): ?int;
 

--- a/src/Entity/PathTrait.php
+++ b/src/Entity/PathTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Entity;
+
+use JMS\Serializer\Annotation as Serial;
+
+trait PathTrait
+{
+  /**
+   * @var string
+   * @ORM\Column(type="string", length=255, nullable=true)
+   */
+  protected $path;
+
+  public function getPath():? string
+  {
+    return $this->path;
+  }
+
+  public function setPath(String $path): void
+  {
+    $this->path = $path;
+  }
+
+  public function getParentPath(): string
+  {
+    $path = $this->getPath();
+    $bits = \explode(PathInterface::PATH_SEPARATOR, $path);
+    \array_pop($bits);
+    return \implode(PathInterface::PATH_SEPARATOR, $bits);
+  }
+
+  public function setChildOf(PathInterface $parent): void
+  {
+    $path = ($parent ? $parent->getPath() : '') . '/' . $this->getId();
+    $this->setPath($path);
+    foreach ($this->getBranches() as $branch)
+    {
+      $branch->setChildOf($this);
+    }
+    $this->setParent($parent);
+  }
+}

--- a/src/Entity/PathTrait.php
+++ b/src/Entity/PathTrait.php
@@ -12,6 +12,11 @@ trait PathTrait
    */
   protected $path;
 
+  public function getEncodedId(): string
+  {
+    return \base_convert((string) $this->getId(), 10, 32);
+  }
+
   public function getPath():? string
   {
     return $this->path;
@@ -32,7 +37,7 @@ trait PathTrait
 
   public function setChildOf(PathInterface $parent): void
   {
-    $path = ($parent ? $parent->getPath() : '') . '/' . $this->getId();
+    $path = ($parent ? $parent->getPath() : '') . '/' . $this->getEncodedId();
     $this->setPath($path);
     foreach ($this->getBranches() as $branch)
     {

--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -7,12 +7,15 @@ use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as Serial;
 
 /**
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="App\Repository\TreeRepository")
+ * @ORM\Table(indexes={@ORM\Index(name="path_idx", columns={"path"})})
  * @Serial\ExclusionPolicy("all")
  */
-class Store implements BranchInterface
+class Store implements BranchInterface, PathInterface, TreeInterface
 {
     use BranchTrait;
+    use PathTrait;
+    use TreeTrait;
     /**
      * @ORM\Id()
      * @ORM\GeneratedValue()

--- a/src/Entity/TreeInterface.php
+++ b/src/Entity/TreeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\Collection;
+
+interface TreeInterface
+{
+  public function buildTree(Collection $nodes);
+}

--- a/src/Entity/TreeTrait.php
+++ b/src/Entity/TreeTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\Collection;
+
+trait TreeTrait
+{
+  public function buildTree(Collection $nodes): void
+  {
+    /** @var PathInterface[] **/
+    $tree = [$this->getPath() => $this];
+
+    foreach($nodes as $node)
+    {
+      $tree[$node->getPath()] = $node;
+      $parent = $tree[$node->getParentPath()] ?? null;
+      $node->setParent($parent);
+      if ($parent) {
+        $parent->addBranch($node);
+      }
+    }
+  }
+}

--- a/src/Migrations/Version20190128004515.php
+++ b/src/Migrations/Version20190128004515.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Swap out foreign key for path
+ */
+final class Version20190128004515 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Swap out foreign key for path';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
+
+        $this->addSql('DROP INDEX IDX_FF575877727ACA70');
+        $this->addSql('CREATE TEMPORARY TABLE __temp__store AS SELECT id, name FROM store');
+        $this->addSql('DROP TABLE store');
+        $this->addSql('CREATE TABLE store (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(255) NOT NULL COLLATE BINARY, path VARCHAR(255) DEFAULT NULL)');
+        $this->addSql('INSERT INTO store (id, name) SELECT id, name FROM __temp__store');
+        $this->addSql('DROP TABLE __temp__store');
+        $this->addSql('CREATE INDEX path_idx ON store (path)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
+
+        $this->addSql('DROP INDEX path_idx');
+        $this->addSql('CREATE TEMPORARY TABLE __temp__store AS SELECT id, name FROM store');
+        $this->addSql('DROP TABLE store');
+        $this->addSql('CREATE TABLE store (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(255) NOT NULL, parent_id INTEGER DEFAULT NULL)');
+        $this->addSql('INSERT INTO store (id, name) SELECT id, name FROM __temp__store');
+        $this->addSql('DROP TABLE __temp__store');
+        $this->addSql('CREATE INDEX IDX_FF575877727ACA70 ON store (parent_id)');
+    }
+}

--- a/src/Repository/TreeRepository.php
+++ b/src/Repository/TreeRepository.php
@@ -22,6 +22,7 @@ class TreeRepository extends EntityRepository
     $q = $this->createQueryBuilder('n')
               ->andWhere('n.path like :path')
               ->andWhere('n.id != :id')
+              ->addOrderBy('n.path')
               ->setParameter('id', $parent->getId())
               ->setParameter('path', $parent->getPath() . '%');
     return $q->getQuery()->getResult();

--- a/src/Repository/TreeRepository.php
+++ b/src/Repository/TreeRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\TreeInterface;
+use App\Entity\PathInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityRepository;
+
+class TreeRepository extends EntityRepository
+{
+  public function getRootNodes(): array
+  {
+    $q = $this->createQueryBuilder('n')
+              ->andWhere('n.path not like :path')
+              ->setParameter('path', '/%/%');
+    return $q->getQuery()->getResult();
+  }
+
+  public function getNodes(PathInterface $parent): array
+  {
+    $q = $this->createQueryBuilder('n')
+              ->andWhere('n.path like :path')
+              ->andWhere('n.id != :id')
+              ->setParameter('id', $parent->getId())
+              ->setParameter('path', $parent->getPath() . '%');
+    return $q->getQuery()->getResult();
+  }
+
+  public function buildTree(TreeInterface $parent)
+  {
+    $parent->buildTree(new ArrayCollection($this->getNodes($parent)));
+  }
+
+  public function getFullTree(): array
+  {
+    $rootNodes = $this->getRootNodes();
+    foreach ($rootNodes as $node) {
+      $this->buildTree($node);
+    }
+    return $rootNodes;
+  }
+
+  public function remove(PathInterface $node)
+  {
+    $branches = $this->getNodes($node);
+    $branches[] = $node;
+    $builder = $this->getEntityManager()->createQueryBuilder()
+        ->delete($this->getClassName(), 'n')
+        ->where('n in (:nodes)')
+        ->setParameter(':nodes', $branches);
+    $builder->getQuery()->execute();
+  }
+}

--- a/src/Repository/TreeRepository.php
+++ b/src/Repository/TreeRepository.php
@@ -12,8 +12,8 @@ class TreeRepository extends EntityRepository
   public function getRootNodes(): array
   {
     $q = $this->createQueryBuilder('n')
-              ->andWhere('n.path not like :path')
-              ->setParameter('path', '/%/%');
+              ->andWhere('length(n.path) <= :length')
+              ->setParameter('length', PathInterface::ID_LENGTH);
     return $q->getQuery()->getResult();
   }
 

--- a/tests/unit/Controller/StoresControllerTest.php
+++ b/tests/unit/Controller/StoresControllerTest.php
@@ -58,10 +58,11 @@ class StoresControllerTest extends TestCase
     $data = ['name' => 'new store'];
     $request = new Request([], $data);
     $this->entityManager->expects(static::once())->method('persist');
-    $this->entityManager->expects(static::once())->method('flush');
+    $this->entityManager->expects(static::exactly(2))->method('flush');
     $result = $this->controller->postAction($request);
     $this->assertInstanceOf(Store::class, $result, 'returns a store');
     $this->assertEquals('new store', $result->getName(), 'name set correctly');
+    $this->assertEquals('/', $result->getPath(), 'default path set');
   }
 
   public function testPostBranchAction(): void

--- a/tests/unit/Controller/StoresControllerTest.php
+++ b/tests/unit/Controller/StoresControllerTest.php
@@ -62,7 +62,7 @@ class StoresControllerTest extends TestCase
     $result = $this->controller->postAction($request);
     $this->assertInstanceOf(Store::class, $result, 'returns a store');
     $this->assertEquals('new store', $result->getName(), 'name set correctly');
-    $this->assertEquals('/0', $result->getPath(), 'default path set');
+    $this->assertEquals('00000', $result->getPath(), 'default path set');
   }
 
   public function testPostBranchAction(): void

--- a/tests/unit/Controller/StoresControllerTest.php
+++ b/tests/unit/Controller/StoresControllerTest.php
@@ -4,8 +4,8 @@ namespace App\Tests\Unit\Controller;
 
 use App\Controller\StoresController;
 use App\Entity\Store;
+use App\Repository\TreeRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -23,9 +23,9 @@ class StoresControllerTest extends TestCase
   public function testCgetAction(): void
   {
     $stores = [new Store()];
-    $repo = $this->createMock(EntityRepository::class);
+    $repo = $this->createMock(TreeRepository::class);
     $this->entityManager->method('GetRepository')->willReturn($repo);
-    $repo->expects(static::once())->method('findBy')->willReturn($stores);
+    $repo->expects(static::once())->method('getFullTree')->willReturn($stores);
     $result = $this->controller->cgetAction();
     $this->assertEquals($stores, $result, 'returns the stores');
   }
@@ -42,7 +42,10 @@ class StoresControllerTest extends TestCase
 
   public function testGetBranchesAction(): void
   {
+    $repo = $this->createMock(TreeRepository::class);
+    $this->entityManager->method('GetRepository')->willReturn($repo);
     $store = new Store();
+    $repo->expects(static::once())->method('buildTree')->with($store);
     $this->assertEquals(
       $store,
       $this->controller->getBranchesAction($store),
@@ -92,7 +95,12 @@ class StoresControllerTest extends TestCase
     $store = new Store();
     $oldParent = new Store();
     $store->setParent($oldParent);
+    $branch = new Store();
+    $store->addBranch($branch);
     $newParent = new Store();
+    $repo = $this->createMock(TreeRepository::class);
+    $this->entityManager->method('GetRepository')->willReturn($repo);
+    $repo->expects(static::once())->method('buildTree')->with($store);
     $this->entityManager->expects(static::once())->method('flush');
     $result = $this->controller->putParentAction($store, $newParent);
     $this->assertInstanceOf(Store::class, $result, 'returns a store');
@@ -103,9 +111,10 @@ class StoresControllerTest extends TestCase
 
   public function testDeleteAction(): void
   {
+    $repo = $this->createMock(TreeRepository::class);
+    $this->entityManager->method('GetRepository')->willReturn($repo);
     $store = new Store();
-    $this->entityManager->expects(static::once())->method('remove')->with($store);
-    $this->entityManager->expects(static::once())->method('flush');
+    $repo->expects(static::once())->method('remove')->with($store);
     $result = $this->controller->deleteAction($store);
   }
 }

--- a/tests/unit/Controller/StoresControllerTest.php
+++ b/tests/unit/Controller/StoresControllerTest.php
@@ -62,7 +62,7 @@ class StoresControllerTest extends TestCase
     $result = $this->controller->postAction($request);
     $this->assertInstanceOf(Store::class, $result, 'returns a store');
     $this->assertEquals('new store', $result->getName(), 'name set correctly');
-    $this->assertEquals('/', $result->getPath(), 'default path set');
+    $this->assertEquals('/0', $result->getPath(), 'default path set');
   }
 
   public function testPostBranchAction(): void

--- a/tests/unit/Entity/PathTest.php
+++ b/tests/unit/Entity/PathTest.php
@@ -20,7 +20,7 @@ class PathTest extends TestCase
       use BranchTrait;
       use PathTrait;
       public function getId(): int {
-        return 3;
+        return 341123;
       }
     };
   }
@@ -34,6 +34,6 @@ class PathTest extends TestCase
     $newParent = new $this->class();
     $newParent->setPath('/5');
     $node->setChildOf($newParent);
-    $this->assertEquals('/5/3', $node->getPath());
+    $this->assertEquals('/5/ad43', $node->getPath());
   }
 }

--- a/tests/unit/Entity/PathTest.php
+++ b/tests/unit/Entity/PathTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\BranchInterface;
+use App\Entity\BranchTrait;
+use App\Entity\PathInterface;
+use App\Entity\PathTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use PHPUnit\Framework\TestCase;
+
+class PathTest extends TestCase
+{
+  private $class;
+
+  public function setup()
+  {
+    $this->class = new class implements PathInterface, BranchInterface {
+      use BranchTrait;
+      use PathTrait;
+      public function getId(): int {
+        return 3;
+      }
+    };
+  }
+
+  public function testPaths()
+  {
+    $node = new $this->class();
+    $this->assertNull($node->getPath());
+    $node->setPath('/1/2/3');
+    $this->assertEquals('/1/2', $node->getParentPath());
+    $newParent = new $this->class();
+    $newParent->setPath('/5');
+    $node->setChildOf($newParent);
+    $this->assertEquals('/5/3', $node->getPath());
+  }
+}

--- a/tests/unit/Entity/PathTest.php
+++ b/tests/unit/Entity/PathTest.php
@@ -19,8 +19,9 @@ class PathTest extends TestCase
     $this->class = new class implements PathInterface, BranchInterface {
       use BranchTrait;
       use PathTrait;
+      public $id = 341123;
       public function getId(): int {
-        return 341123;
+        return $this->id;
       }
     };
   }
@@ -29,11 +30,25 @@ class PathTest extends TestCase
   {
     $node = new $this->class();
     $this->assertNull($node->getPath());
-    $node->setPath('/1/2/3');
-    $this->assertEquals('/1/2', $node->getParentPath());
+    $node->setPath('000010000200003');
+    $this->assertEquals('0000100002', $node->getParentPath());
     $newParent = new $this->class();
-    $newParent->setPath('/5');
+    $newParent->setPath('00005');
     $node->setChildOf($newParent);
-    $this->assertEquals('/5/ad43', $node->getPath());
+    $this->assertEquals('0000507b7n', $node->getPath());
+    $newParent->setPath(\str_pad("5", 251, "0")); // Child path will be too long!
+    $this->expectException(\LogicException::class);
+    $node->setChildOf($newParent);
+
+  }
+
+  public function testEncoding()
+  {
+    $node = new $this->class();
+    $node->id = 60466175;
+    $this->assertEquals('zzzzz', $node->getEncodedId());
+    $node->id = 60466177; // ID is too large
+    $this->expectException(\LogicException::class);
+    $node->getEncodedId();
   }
 }

--- a/tests/unit/Entity/TreeTest.php
+++ b/tests/unit/Entity/TreeTest.php
@@ -27,9 +27,9 @@ class TreeTest extends TestCase
   public function test()
   {
     $parent = new $this->class();
-    $parent->setPath('/1');
+    $parent->setPath('00001');
     $child = new $this->class();
-    $child->setPath('/1/2');
+    $child->setPath('0000100002');
     $parent->buildTree(new ArrayCollection([$child]));
     $this->assertContains($child, $parent->getBranches(), 'child added');
     $this->assertEquals($parent, $child->getParent(), 'parent set');

--- a/tests/unit/Entity/TreeTest.php
+++ b/tests/unit/Entity/TreeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+class TreeTest extends TestCase
+{
+  private $class;
+
+  public function setup()
+  {
+    $this->class = new class implements Entity\TreeInterface,
+      Entity\PathInterface,
+      Entity\BranchInterface {
+      use Entity\TreeTrait;
+      use Entity\PathTrait;
+      use Entity\BranchTrait;
+      public function getId(): ?int {
+        return 1;
+      }
+    };
+  }
+
+  public function test()
+  {
+    $parent = new $this->class();
+    $parent->setPath('/1');
+    $child = new $this->class();
+    $child->setPath('/1/2');
+    $parent->buildTree(new ArrayCollection([$child]));
+    $this->assertContains($child, $parent->getBranches(), 'child added');
+    $this->assertEquals($parent, $child->getParent(), 'parent set');
+  }
+}

--- a/tests/unit/Repository/TreeRepositoryTest.php
+++ b/tests/unit/Repository/TreeRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Tests\Unit\Repository;
+
+use App\Entity\Store;
+use App\Repository\TreeRepository;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+
+class TreeRepositoryTest extends TestCase
+{
+  /** @var EntityManagerInterface */
+  private $entityManager;
+  /** @var ClassMetadata */
+  private $meta;
+  /** @var TreeRepository */
+  private $repo;
+
+  public function setup()
+  {
+    $this->entityManager = $this->createMock(EntityManagerInterface::class);
+    $this->meta = new ClassMetadata(Store::class);
+    $this->repo = new TreeRepository($this->entityManager, $this->meta);
+  }
+
+  public function testGetRootNodes()
+  {
+    $queryBuilder = $this->createMock(QueryBuilder::class);
+    $this->entityManager->method('createQueryBuilder')->willReturn($queryBuilder);
+    $query = $this->createMock(AbstractQuery::class);
+    $queryBuilder->method('getQuery')->willReturn($query);
+    $queryBuilder->method(static::anything())->willReturnSelf();
+    $stores = [new Store()];
+    $query->method('getResult')->willReturn($stores);
+    $result = $this->repo->getRootNodes();
+    $this->assertEquals($stores, $result, 'stores returned');
+  }
+
+  public function testGetNodes()
+  {
+    $queryBuilder = $this->createMock(QueryBuilder::class);
+    $this->entityManager->method('createQueryBuilder')->willReturn($queryBuilder);
+    $query = $this->createMock(AbstractQuery::class);
+    $queryBuilder->method('getQuery')->willReturn($query);
+    $queryBuilder->method(static::anything())->willReturnSelf();
+    $rootStore = new Store();
+    $stores = [new Store()];
+    $query->method('getResult')->willReturn($stores);
+    $result = $this->repo->getNodes($rootStore);
+    $this->assertEquals($stores, $result, 'stores returned');
+  }
+
+  public function testBuildTree()
+  {
+    $this->repo = $this->getMockBuilder(TreeRepository::class)
+                       ->setMethods(['getNodes'])
+                       ->setConstructorArgs([$this->entityManager, $this->meta])
+                       ->getMock();
+    $rootStore = $this->createMock(Store::class);
+    $rootStore->expects(static::once())->method('buildTree')
+              ->with(static::isinstanceof(Collection::class));
+    $stores = [new Store()];
+    $this->repo->expects(static::once())->method('getNodes')->with($rootStore)
+                                                            ->willReturn($stores);
+    $this->repo->buildTree($rootStore);
+  }
+
+  public function testGetFullTree()
+  {
+    $this->repo = $this->getMockBuilder(TreeRepository::class)
+                       ->setMethods(['getRootNodes', 'buildTree'])
+                       ->setConstructorArgs([$this->entityManager, $this->meta])
+                       ->getMock();
+    $rootNode = $this->createMock(Store::class);
+    $this->repo->expects(static::once())->method('getRootNodes')
+                                        ->willReturn([$rootNode]);
+    $this->repo->expects(static::once())->method('buildTree')->with($rootNode);
+    $result = $this->repo->getFullTree();
+    $this->assertContains($rootNode, $result, 'root store returned');
+  }
+
+  public function testRemove()
+  {
+    $this->repo = $this->getMockBuilder(TreeRepository::class)
+                       ->setMethods(['getNodes'])
+                       ->setConstructorArgs([$this->entityManager, $this->meta])
+                       ->getMock();
+    $rootStore = new Store();
+    $stores = [new Store()];
+    $this->repo->expects(static::once())->method('getNodes')->with($rootStore)
+                                                            ->willReturn($stores);
+    $queryBuilder = $this->createMock(QueryBuilder::class);
+    $this->entityManager->method('createQueryBuilder')->willReturn($queryBuilder);
+    $query = $this->createMock(AbstractQuery::class);
+    $queryBuilder->method('getQuery')->willReturn($query);
+    $queryBuilder->method(static::anything())->willReturnSelf();
+    $query->expects(static::once())->method('execute');
+    $this->repo->remove($rootStore);
+  }
+}


### PR DESCRIPTION
I have personally worked on Closure Table solutions in the past and I recognise
they are quite efficient and easy to query, however I would like to demonstrate
here my ability to learn a new thing by implementing the Materialised Path solution.
I did also consider the Nested Set solution, and could implement that using a
helper library, but it turned out to be far too complex to implement myself.

This reduces the number of queries to equal to the number of root nodes plus one
to get the root nodes.